### PR TITLE
fix: shtml check domainWhiteList hostname get null

### DIFF
--- a/lib/helper/shtml.js
+++ b/lib/helper/shtml.js
@@ -30,8 +30,12 @@ module.exports = function shtml(val) {
         if (value[0] === '/' || value[0] === '#') {
           return;
         }
+        
+        const hostname = urlparse(value).hostname;
+        if (!hostname) {
+          return;
+        };
 
-        const hostname = urlparse(value).hostname.toLowerCase();
         // If we don't have our hostname in the app.security.domainWhiteList,
         // Just check for `shtmlConfig.domainWhiteList` and `ctx.whiteList`.
         if (!isSafeDomain(hostname, domainWhiteList)) {

--- a/lib/helper/shtml.js
+++ b/lib/helper/shtml.js
@@ -30,11 +30,11 @@ module.exports = function shtml(val) {
         if (value[0] === '/' || value[0] === '#') {
           return;
         }
-        
+
         const hostname = urlparse(value).hostname;
         if (!hostname) {
           return;
-        };
+        }
 
         // If we don't have our hostname in the app.security.domainWhiteList,
         // Just check for `shtmlConfig.domainWhiteList` and `ctx.whiteList`.

--- a/test/app/extends/helper.test.js
+++ b/test/app/extends/helper.test.js
@@ -75,6 +75,13 @@ describe('test/app/extends/helper.test.js', function() {
         .expect('true', done);
     });
 
+    it('should escape hostname null', function(done) {
+      this.app.httpRequest()
+        .get('/shtml-escape-hostname-null')
+        .expect(200)
+        .expect('true', done);
+    });
+
     it('should support configuration', function(done) {
       this.app2.httpRequest()
         .get('/shtml-configuration')

--- a/test/fixtures/apps/helper-app/app/router.js
+++ b/test/fixtures/apps/helper-app/app/router.js
@@ -27,6 +27,10 @@ module.exports = function(app) {
     this.body = this.helper.shtml('<h1>Hello</h1><img onload="alert(1);" src="http://domain.com/1.png" title="this is image">') == '<h1>Hello</h1><img src="http://domain.com/1.png" title="this is image">';
   });
 
+  app.get('/shtml-escape-hostname-null', function*() {
+    this.body = this.helper.shtml('<a href="javascript:;">test</a>') == '<a href>test</a>';
+  });
+
   app.get('/shtml-ignore-domains-not-in-default-domainList', function*() {
     this.body = this.helper.shtml('<img src="http://shaoshuai.me" alt="alt"><a href="http://shaoshuai.me">xx</a>') == '<img alt="alt"><a>xx</a>';
   });


### PR DESCRIPTION
like `<a href="javascript:;">test</a>` this url check hostname will get null and meet TypeError: Cannot read property 'toLocaleLowerCase' of null error。

So, add check hostname is null and remove toLowerCase，because in isSafeDomain function have use toLowerCase method to domain。